### PR TITLE
#88 Add view and banned account api

### DIFF
--- a/Gigbuds_BE.API/Controllers/AccountsController.cs
+++ b/Gigbuds_BE.API/Controllers/AccountsController.cs
@@ -1,0 +1,25 @@
+using System;
+using Gigbuds_BE.Application.Features.Accounts;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Gigbuds_BE.API.Controllers;
+
+public class AccountsController(IMediator _mediator) : _BaseApiController
+{
+    [HttpGet()]    
+    [AllowAnonymous]
+    public async Task<IActionResult> GetAllAccount() {
+        var query = new GetAllAccountQuery();
+        var result = await _mediator.Send(query);
+        return Ok(result);
+    }
+
+    [HttpPut("banned/{id}")]
+    public async Task<IActionResult> BanAccount(int id) {
+        var command = new BanAccountCommand(id);
+        var result = await _mediator.Send(command);
+        return Ok(result);
+    }
+}

--- a/Gigbuds_BE.API/Controllers/JobSeekersController.cs
+++ b/Gigbuds_BE.API/Controllers/JobSeekersController.cs
@@ -1,8 +1,10 @@
 ﻿using AutoMapper;
 using Gigbuds_BE.Application.DTOs.ApplicationUsers;
+using Gigbuds_BE.Application.Features.Accounts;
 using Gigbuds_BE.Application.Features.Accounts.JobSeekers.Commands.EditJobSeeker;
 using Gigbuds_BE.Application.Features.Accounts.JobSeekers.Queries.GetJobSeekerDetail;
 using Gigbuds_BE.Application.Features.Accounts.JobSeekers.Queries.GetJobSeekerLocations;
+using Gigbuds_BE.Application.Features.Memberships.Queries;
 using Gigbuds_BE.Domain.Exceptions;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -116,5 +118,6 @@ namespace Gigbuds_BE.API.Controllers
                 });
             }
         }
+
     }
 }

--- a/Gigbuds_BE.Application/DTOs/AccountDto.cs
+++ b/Gigbuds_BE.Application/DTOs/AccountDto.cs
@@ -1,0 +1,23 @@
+using System;
+using Gigbuds_BE.Application.DTOs.ApplicationUsers;
+
+namespace Gigbuds_BE.Application.DTOs;
+
+public class AccountDto
+{
+    public DateTime Dob { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    public string Password { get; set; }
+    public string SocialSecurityNumber { get; set; }
+    public bool IsMale { get; set; } = true;
+    public int AvailableJobApplication { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public string? RefreshToken { get; set; }
+    public string? CurrentLocation { get; set; }
+    public string AvatarUrl { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public List<string> Roles { get; set; }
+    public EmployerProfileResponseDto employerProfileResponseDto { get; set; }
+}

--- a/Gigbuds_BE.Application/Features/Accounts/BanAccountCommand.cs
+++ b/Gigbuds_BE.Application/Features/Accounts/BanAccountCommand.cs
@@ -1,0 +1,16 @@
+using System;
+using MediatR;
+
+namespace Gigbuds_BE.Application.Features.Accounts;
+
+public class BanAccountCommand : IRequest<bool>
+{
+    public int Id { get; set; }
+    public bool IsEnabled { get; set; }
+
+    public BanAccountCommand(int id, bool isEnabled)
+    {
+        Id = id;
+        IsEnabled = isEnabled;
+    }
+}

--- a/Gigbuds_BE.Application/Features/Accounts/GetAllAccountQuery.cs
+++ b/Gigbuds_BE.Application/Features/Accounts/GetAllAccountQuery.cs
@@ -1,0 +1,11 @@
+using System;
+using Gigbuds_BE.Application.DTOs;
+using Gigbuds_BE.Application.DTOs.ApplicationUsers;
+using MediatR;
+
+namespace Gigbuds_BE.Application.Features.Accounts;
+
+public class GetAllAccountQuery : IRequest<List<AccountDto>>
+{
+    
+}

--- a/Gigbuds_BE.Application/Features/Accounts/GetAllAccountQueryHandler.cs
+++ b/Gigbuds_BE.Application/Features/Accounts/GetAllAccountQueryHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using AutoMapper;
+using Gigbuds_BE.Application.DTOs;
+using Gigbuds_BE.Application.Interfaces;
+using Gigbuds_BE.Application.Interfaces.Repositories;
+using Gigbuds_BE.Application.Interfaces.Services;
+using Gigbuds_BE.Application.Specifications.ApplicationUsers;
+using Gigbuds_BE.Domain.Entities.Identity;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.VisualBasic;
+
+namespace Gigbuds_BE.Application.Features.Accounts;
+    
+public class GetAllAccountQueryHandler(IUnitOfWork unitOfWork, IApplicationUserService<ApplicationUser> applicationUserService, IMapper mapper, UserManager<ApplicationUser> userManager) : IRequestHandler<GetAllAccountQuery, List<AccountDto>>
+{
+
+    public async Task<List<AccountDto>> Handle(GetAllAccountQuery request, CancellationToken cancellationToken)
+    {
+        var spec = new GetAllAccountSpec();
+        var accounts = await applicationUserService.GetAllUsersWithSpecAsync(spec);
+        var accountDtos = new List<AccountDto>();
+        foreach (var account in accounts)
+        {
+            var dto = mapper.Map<AccountDto>(account);
+            var roles = await userManager.GetRolesAsync(account);
+            dto.Roles = roles.ToList();
+            accountDtos.Add(dto);
+        }
+        return accountDtos;
+    }
+}

--- a/Gigbuds_BE.Application/Features/Accounts/JobSeekers/BanAccountCommandHandler.cs
+++ b/Gigbuds_BE.Application/Features/Accounts/JobSeekers/BanAccountCommandHandler.cs
@@ -1,0 +1,22 @@
+using System;
+using Gigbuds_BE.Application.Interfaces;
+using Gigbuds_BE.Application.Interfaces.Services;
+using Gigbuds_BE.Domain.Entities.Identity;
+using MediatR;
+using Gigbuds_BE.Domain.Exceptions;
+using Gigbuds_BE.Application.Interfaces.Repositories;
+
+namespace Gigbuds_BE.Application.Features.Accounts.JobSeekers;
+
+public class BanAccountCommandHandler(IUnitOfWork unitOfWork, IApplicationUserService<ApplicationUser> applicationUserService) : IRequestHandler<BanAccountCommand, bool>
+{
+    public async Task<bool> Handle(BanAccountCommand request, CancellationToken cancellationToken)
+    {
+        var account = await applicationUserService.GetByIdAsync(request.Id);
+        if (account == null) throw new NotFoundException("Account not found");
+        account.IsEnabled = request.IsEnabled;
+        await applicationUserService.UpdateAsync(account);
+        await unitOfWork.CompleteAsync();
+        return true;
+    }
+}

--- a/Gigbuds_BE.Application/Profiles/AccountProfile.cs
+++ b/Gigbuds_BE.Application/Profiles/AccountProfile.cs
@@ -1,0 +1,17 @@
+using System;
+using AutoMapper;
+using Gigbuds_BE.Application.DTOs;
+using Gigbuds_BE.Domain.Entities.Identity;
+
+namespace Gigbuds_BE.Application.Profiles;
+
+public class AccountProfile : Profile
+{
+    public AccountProfile()
+    {
+        CreateMap<ApplicationUser, AccountDto>()
+        .ForMember(dest => dest.employerProfileResponseDto, opt => opt.MapFrom(
+            src => src.EmployerProfile
+        ));
+    }
+}

--- a/Gigbuds_BE.Application/Specifications/ApplicationUsers/ApplicationUserSpecification.cs
+++ b/Gigbuds_BE.Application/Specifications/ApplicationUsers/ApplicationUserSpecification.cs
@@ -39,4 +39,12 @@ namespace Gigbuds_BE.Application.Specifications.ApplicationUsers
             AddInclude(x => x.Followers.Where(f => f.FollowedAccountId == id));
         }
     }
+
+    public class GetAllAccountSpec : BaseSpecification<ApplicationUser>
+    {
+        public GetAllAccountSpec() : base(x => x.IsEnabled)
+        {
+            AddInclude(x => x.EmployerProfile);
+        }
+    }
 }


### PR DESCRIPTION
Introduces AccountsController with endpoints to get all accounts and ban accounts. Adds AccountDto, related MediatR queries and command handlers, AutoMapper profile, and a specification for retrieving enabled accounts.